### PR TITLE
Add XML comment style

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -20,7 +20,8 @@
         "dashdash",
         "semicolon",
         "rem",
-        "slashstarstar"
+        "slashstarstar",
+        "xml"
       ]
     },
     "includes": {

--- a/internal/pkg/core/comment_style.go
+++ b/internal/pkg/core/comment_style.go
@@ -17,9 +17,10 @@
 package core
 
 import (
-	styles "github.com/fbiville/headache/internal/pkg/core/comment_styles"
 	"log"
 	"strings"
+
+	styles "github.com/fbiville/headache/internal/pkg/core/comment_styles"
 )
 
 type CommentStyle interface {
@@ -53,6 +54,7 @@ func SupportedStyles() []CommentStyle {
 		styles.SemiColon{},
 		styles.Rem{},
 		styles.SlashStarStar{},
+		styles.XML{},
 	}
 }
 

--- a/internal/pkg/core/comment_style_test.go
+++ b/internal/pkg/core/comment_style_test.go
@@ -18,13 +18,14 @@ package core_test
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"sort"
+	"strings"
+
 	. "github.com/fbiville/headache/internal/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"sort"
-	"strings"
 )
 
 var _ = Describe("Comment styles", func() {
@@ -58,6 +59,7 @@ var _ = Describe("Comment styles", func() {
 			"SlashSlash",
 			"SlashStar",
 			"SlashStarStar",
+			"XML",
 		}))
 		Expect(lowerAll(catalog)).To(Equal(sortedStylesInSchema("../../../docs/schema.json")),
 			"Expected all declared styles to be included in JSON schema")

--- a/internal/pkg/core/comment_styles/xml.go
+++ b/internal/pkg/core/comment_styles/xml.go
@@ -22,7 +22,7 @@ func (XML) GetName() string {
 	return "XML"
 }
 func (XML) GetOpeningString() string {
-	return "aaXMLaa"
+	return "<--"
 }
 func (XML) GetString() string {
 	return ""

--- a/internal/pkg/core/comment_styles/xml.go
+++ b/internal/pkg/core/comment_styles/xml.go
@@ -22,7 +22,7 @@ func (XML) GetName() string {
 	return "XML"
 }
 func (XML) GetOpeningString() string {
-	return "<--"
+	return "<!--"
 }
 func (XML) GetString() string {
 	return ""

--- a/internal/pkg/core/comment_styles/xml.go
+++ b/internal/pkg/core/comment_styles/xml.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Florent Biville (@fbiville)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package styles
+
+type XML struct{}
+
+func (XML) GetName() string {
+	return "XML"
+}
+func (XML) GetOpeningString() string {
+	return "aaXMLaa"
+}
+func (XML) GetString() string {
+	return ""
+}
+func (XML) GetClosingString() string {
+	return "bbXMLbb"
+}

--- a/internal/pkg/core/comment_styles/xml.go
+++ b/internal/pkg/core/comment_styles/xml.go
@@ -28,5 +28,5 @@ func (XML) GetString() string {
 	return ""
 }
 func (XML) GetClosingString() string {
-	return "bbXMLbb"
+	return "-->"
 }

--- a/internal/pkg/core/headache.go
+++ b/internal/pkg/core/headache.go
@@ -18,14 +18,15 @@ package core
 
 import (
 	"fmt"
-	"github.com/fbiville/headache/internal/pkg/fs"
-	"github.com/fbiville/headache/internal/pkg/vcs"
-	tpl "html/template"
 	"log"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	tpl "text/template"
+
+	"github.com/fbiville/headache/internal/pkg/fs"
+	"github.com/fbiville/headache/internal/pkg/vcs"
 )
 
 type Headache struct {

--- a/internal/pkg/core/header_detector.go
+++ b/internal/pkg/core/header_detector.go
@@ -18,10 +18,10 @@ package core
 
 import (
 	"fmt"
-	tpl "html/template"
 	"regexp"
 	"sort"
 	"strings"
+	tpl "text/template"
 )
 
 func ComputeHeaderDetectionRegex(lines []string, data map[string]string) (string, error) {

--- a/internal/pkg/core/template_parser.go
+++ b/internal/pkg/core/template_parser.go
@@ -17,9 +17,9 @@
 package core
 
 import (
-	tpl "html/template"
 	"regexp"
 	"strings"
+	tpl "text/template"
 )
 
 type ParsedTemplate struct { // visible for testing


### PR DESCRIPTION
Contributes to https://github.com/fbiville/headache/issues/22.

Adds `xml` format to add comments surrounded by `<!--` and `-->`

Also fixes a bug with template rendering which was using HTML templating, causing escaping of `<` into `&lt;`.
